### PR TITLE
(release) 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="2.0.3"></a>
+## [2.0.3](https://github.com/apartmenttherapy/react-gpt/compare/v2.0.2...v2.0.3) (2019-01-24)
+
+
+### Bug Fixes
+
+* Stop multiple refresh on mq change ([#11](https://github.com/apartmenttherapy/react-gpt/issues/11)) ([3cff653](https://github.com/apartmenttherapy/react-gpt/commit/3cff653))
+
+
+
 <a name="2.0.2"></a>
 ## [2.0.2](https://github.com/apartmenttherapy/react-gpt/compare/v2.0.1...v2.0.2) (2019-01-22)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@atmedia/react-gpt",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "A react display ad component using Google Publisher Tag",
     "main": "lib/index.js",
     "jsnext:main": "es/index.js",


### PR DESCRIPTION
Preparing release 2.0.3 with the following fix:

* Stop multiple refresh calls on media query change ([#11](https://github.com/apartmenttherapy/react-gpt/issues/11)) ([3cff653](https://github.com/apartmenttherapy/react-gpt/commit/3cff653))