### PR TITLE
perf: Use googletag.cmd.push instead of timeout to process queue

### DIFF
--- a/src/createManager.js
+++ b/src/createManager.js
@@ -353,14 +353,6 @@ export class AdManager extends EventEmitter {
             return;
         }
 
-        const checkPubadsReady = cb => {
-            if (this.pubadsReady) {
-                cb();
-            } else {
-                setTimeout(checkPubadsReady, 50, cb);
-            }
-        };
-
         const instances = this.getMountedInstances();
         let hasPubAdsService = false;
         let dummyAdSlot;
@@ -398,8 +390,8 @@ export class AdManager extends EventEmitter {
         // Enable service
         this.googletag.enableServices();
 
-        // After the service is enabled, check periodically until `pubadsReady` flag returns true before proceeding the rest.
-        checkPubadsReady(() => {
+        // Queue commands that should run once the service is ready
+        this.googletag.cmd.push(() => {
             // destroy dummy ad slot if exists.
             if (dummyAdSlot) {
                 this.googletag.destroySlots([dummyAdSlot]);


### PR DESCRIPTION
Use googletag.cmd.push instead of timeout to check if pubads is ready. Fixes recurring
handler perf issue.

<img width="847" alt="screen shot 2019-02-05 at 12 38 01 pm" src="https://user-images.githubusercontent.com/1486298/52293040-f1ee8880-2943-11e9-8c91-87a2df2e43e4.png">
