### PR TITLE
(release) 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="2.1.1"></a>
+## [2.1.1](https://github.com/apartmenttherapy/react-gpt/compare/v2.1.0...v2.1.1) (2019-02-05)
+
+
+### Performance Improvements
+
+* Use googletag.cmd.push instead of timeout to process queue ([#16](https://github.com/apartmenttherapy/react-gpt/issues/16)) ([5af9ce7](https://github.com/apartmenttherapy/react-gpt/commit/5af9ce7))
+
+
+
 <a name="2.1.0"></a>
 # [2.1.0](https://github.com/apartmenttherapy/react-gpt/compare/v2.0.3...v2.1.0) (2019-01-28)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@atmedia/react-gpt",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "A react display ad component using Google Publisher Tag",
     "main": "lib/index.js",
     "jsnext:main": "es/index.js",


### PR DESCRIPTION
Release 2.1.1. Includes:

* Use googletag.cmd.push instead of timeout to process queue ([#16](https://github.com/apartmenttherapy/react-gpt/issues/16)) ([5af9ce7](https://github.com/apartmenttherapy/react-gpt/commit/5af9ce7))