### PR TITLE
Remove enableServices timeout from GPT mock

### DIFF
--- a/src/utils/mockGPT.js
+++ b/src/utils/mockGPT.js
@@ -217,9 +217,7 @@ class GPTMock {
         return this.version;
     }
     enableServices() {
-        setTimeout(() => {
-            this.pubadsReady = true;
-        }, 0);
+        this.pubadsReady = true;
     }
     sizeMapping() {
         if (!this.sizeMappingBuilder) {


### PR DESCRIPTION
Remove `setTimeout` from `enableServices` mock to fix failing tests.